### PR TITLE
fix(Makefile): fix the linker invocation to work on most systems (linux)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,9 @@ else
     ASM := nasm
     ASM_FLAGS := -f elf64 -g
     LINKER := ld
-    LINKER_FLAGS := -o $(EXE) -e _start -lc -lGL
+    LINKER_FLAGS := --dynamic-linker /lib64/ld-linux-x86-64.so.2 -o $(EXE) -e _start --copy-dt-needed-entries -lc -lGL
     LIB_DIR := ./libs/nix
-    LIBS := $(wildcard $(LIB_DIR)/*.a)
+    LIBS := $(wildcard $(LIB_DIR)/*.a) -lc -lGL
 endif
 
 # Display Backend Specific Sources


### PR DESCRIPTION
This pull request includes a change to the `Makefile` to adjust the linker flags and library dependencies for dynamic linking. The most important changes include modifying the `LINKER_FLAGS` and `LIBS` variables.

Changes to `Makefile`:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L56-R58): Updated `LINKER_FLAGS` to include `--dynamic-linker /lib64/ld-linux-x86-64.so.2` and `--copy-dt-needed-entries` for dynamic linking.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L56-R58): Modified `LIBS` to include additional libraries `-lc` and `-lGL`.